### PR TITLE
New image with Julia v0.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 hs_err_pid*
 
 *.idea
+
+# MacOS
+.DS_Store

--- a/images/julia.v0.7-jupyter/Dockerfile
+++ b/images/julia.v0.7-jupyter/Dockerfile
@@ -1,0 +1,18 @@
+FROM ufoym/deepo:all-jupyter-py36-cu90
+
+COPY install_julia_package.jl /
+# ===== ssh service =====
+RUN sed -i 's/archive.ubuntu.com/mirrors.ustc.edu.cn/g' /etc/apt/sources.list && \
+    apt update && \
+    apt install -y openssh-server openssh-client && \
+    apt-get clean && \
+    apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/* /tmp/* ~/*
+
+RUN wget -O julia_bin.tar.gz https://julialang-s3.julialang.org/bin/linux/x64/0.7/julia-0.7.0-linux-x86_64.tar.gz && \
+    tar xzf julia_bin.tar.gz
+
+RUN ./julia-0.7.0/bin/julia -e "ENV[\"JUPYTER\"]=\"jupyter\"; using Pkg; Pkg.resolve(); Pkg.add(\"IJulia\")" && \
+    ./julia-0.7.0/bin/julia /install_julia_package.jl
+
+ENV PATH=$(pwd)/julia-0.7.0/bin:$PATH

--- a/images/julia.v0.7-jupyter/Dockerfile
+++ b/images/julia.v0.7-jupyter/Dockerfile
@@ -15,4 +15,4 @@ RUN wget -O julia_bin.tar.gz https://julialang-s3.julialang.org/bin/linux/x64/0.
 RUN ./julia-0.7.0/bin/julia -e "ENV[\"JUPYTER\"]=\"jupyter\"; using Pkg; Pkg.resolve(); Pkg.add(\"IJulia\")" && \
     ./julia-0.7.0/bin/julia /install_julia_package.jl
 
-ENV PATH=$(pwd)/julia-0.7.0/bin:$PATH
+ENV PATH=/julia-0.7.0/bin:$PATH

--- a/images/julia.v0.7-jupyter/README.md
+++ b/images/julia.v0.7-jupyter/README.md
@@ -1,4 +1,15 @@
 # julia.v0.7-jupyter
 
-from []()
-using Julia version 0.7
+## included packages:
+- IJulia
+- DataFrames, CSV, Query
+- DataStructures, LightGraphs, Calculus, DataFrames,
+- StatsBase, Distributions, HypothesisTests, GLM,
+- JuMP, Optim, Roots, ODBC, JDBC,
+- Knet, Clusterig, DecisionTree, PyCall,
+- JSON, HDF5, JLD, QuantEcon
+- Plots, PyPlot, PlotlyJS,
+- ProgressMeter
+
+## install custom packages
+<!--TODO: how to add custom packages-->

--- a/images/julia.v0.7-jupyter/README.md
+++ b/images/julia.v0.7-jupyter/README.md
@@ -1,0 +1,4 @@
+# julia.v0.7-jupyter
+
+from []()
+using Julia version 0.7

--- a/images/julia.v0.7-jupyter/README.md
+++ b/images/julia.v0.7-jupyter/README.md
@@ -1,15 +1,32 @@
 # julia.v0.7-jupyter
 
 ## included packages:
-- IJulia
-- DataFrames, CSV, Query
-- DataStructures, LightGraphs, Calculus, DataFrames,
-- StatsBase, Distributions, HypothesisTests, GLM,
-- JuMP, Optim, Roots, ODBC, JDBC,
-- Knet, Clusterig, DecisionTree, PyCall,
-- JSON, HDF5, JLD, QuantEcon
-- Plots, PyPlot, PlotlyJS,
-- ProgressMeter
+- `IJulia`
+- tabular data: `DataFrames`, `CSV`, `Query`
+- JuliaPro:
+    - General programming: `DataStructures`, `LightGraphs`,
+    - General Math: `Calculus`, `StatsBase`, `Distributions`, `HypothesisTests`, `GLM`,
+    - Optimization: `JuMP`, `Optim`, `Roots`,
+    - Machine Learning: `Knet`, `Clusterig`, `DecisionTree`,
+    - Interaction with other languages: `PyCall`,
+    - File and data formats: `JSON`, `HDF5`, `JLD`,
+- Visualization: `Plots`, `PyPlot`, `PlotlyJS`,
+- Databases: `ODBC`, `JDBC`, `SQLite`
+- Misc: `ProgressMeter`
 
 ## install custom packages
-<!--TODO: how to add custom packages-->
+
+create your own `install_julia_packages.jl` and
+add `julia /userhome/install_julia_packages.jl` before
+the `jupyter notebook` command.
+
+`install_julia_packages.jl` file template:
+
+```julia
+using Pkg
+Pkg.add.([
+    "Package 1",
+    "Package 2",
+    ...
+    ])
+```

--- a/images/julia.v0.7-jupyter/install_julia_package.jl
+++ b/images/julia.v0.7-jupyter/install_julia_package.jl
@@ -1,0 +1,23 @@
+using Pkg
+Pkg.add.([
+          # tabular
+          "DataFrames", "CSV", "Query"
+
+          # JuliaPro
+          "DataStructures", "LightGraphs", "Calculus", "DataFrames",
+          "StatsBase", "Distributions", "HypothesisTests", "GLM",
+          "JuMP", "Optim", "Roots", "ODBC", "JDBC",
+          "Knet", "Clusterig", "DecisionTree", "PyCall",
+          "JSON", "HDF5", "JLD", "QuantEcon",
+
+          # JuliaPlots
+          "Plots", "PyPlot", "PlotlyJS",
+
+          # DSP
+          "DSP", "Wavelets", "Deconvolution",
+
+          # "MXNet"  # not supported yet
+
+          # MISC
+          "ProgressMeter",
+         ])

--- a/images/julia.v0.7-jupyter/install_julia_package.jl
+++ b/images/julia.v0.7-jupyter/install_julia_package.jl
@@ -1,7 +1,7 @@
 using Pkg
 Pkg.add.([
           # tabular
-          "DataFrames", "CSV", "Query"
+          "DataFrames", "CSV", "Query",
 
           # JuliaPro
           "DataStructures", "LightGraphs", "Calculus", "DataFrames",

--- a/images/julia.v0.7-jupyter/install_julia_package.jl
+++ b/images/julia.v0.7-jupyter/install_julia_package.jl
@@ -9,6 +9,7 @@ Pkg.add.([
           "JuMP", "Optim", "Roots", "ODBC", "JDBC",
           "Knet", "Clustering", "DecisionTree", "PyCall",
           "JSON", "HDF5", "JLD", "QuantEcon",
+          "SQLite",
 
           # JuliaPlots
           "Plots", "PyPlot", "PlotlyJS",

--- a/images/julia.v0.7-jupyter/install_julia_package.jl
+++ b/images/julia.v0.7-jupyter/install_julia_package.jl
@@ -7,7 +7,7 @@ Pkg.add.([
           "DataStructures", "LightGraphs", "Calculus", "DataFrames",
           "StatsBase", "Distributions", "HypothesisTests", "GLM",
           "JuMP", "Optim", "Roots", "ODBC", "JDBC",
-          "Knet", "Clusterig", "DecisionTree", "PyCall",
+          "Knet", "Clustering", "DecisionTree", "PyCall",
           "JSON", "HDF5", "JLD", "QuantEcon",
 
           # JuliaPlots


### PR DESCRIPTION
The jupyter notebook can run a Julia kernel now.

From [ufoym/deepo:all-jupyter-py36-cu90](https://github.com/ufoym/deepo), installed [Julia v0.7](https://julialang.org/), and additional Julia packages, including [IJulia](https://github.com/JuliaLang/IJulia.jl) and those in [JuliaPro](https://juliacomputing.com/products/juliapro.html).