### PR TITLE
deepo.all-py27

### DIFF
--- a/images/deepo.all-py27
+++ b/images/deepo.all-py27
@@ -1,0 +1,11 @@
+FROM ufoym/deepo:py27
+
+RUN sed -i 's/archive.ubuntu.com/mirrors.ustc.edu.cn/g' /etc/apt/sources.list && \
+    apt update && \
+    apt install -y openssh-server openssh-client && \
+    apt install opencv-python && \
+    apt install easydict && \
+    apt install shapely && \
+    apt install swig && \
+    apt-get clean && \
+    apt-get autoremove && \


### PR DESCRIPTION
Deepo is a series of Docker images that

allows you to quickly set up your deep learning research environment
supports almost all commonly used deep learning frameworks: theano, tensorflow, sonnet, pytorch, keras, lasagne, mxnet, cntk, chainer, caffe, torch
and their Dockerfile generator that

allows you to customize your own environment with Lego-like modules
automatically resolves the dependencies for you

python2.7