### PR TITLE
add tf113-cuda10

### DIFF
--- a/images/tf113-cuda10/Dockerfile
+++ b/images/tf113-cuda10/Dockerfile
@@ -1,0 +1,15 @@
+FROM tensorflow/tensorflow:1.13.0rc1-gpu-py3
+USER root
+RUN cp /etc/apt/sources.list /etc/apt/sources.list.bak \
+    && echo deb https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial main restricted universe multiverse > /etc/apt/sources.list \
+    && echo deb https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-updates main restricted universe multiverse >> /etc/apt/sources.list \
+    && echo deb https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-backports main restricted universe multiverse >> /etc/apt/sources.list \
+    && echo deb https://mirrors.tuna.tsinghua.edu.cn/ubuntu/ xenial-security main restricted universe multiverse >> /etc/apt/sources.list \
+    && apt update
+RUN buildDeps='gcc libsm6 libxext6 vim tmux screen' \
+    && apt-get install -y $buildDeps --fix-missing
+
+USER root
+RUN pythonPkg='numpy opencv-python lmdb tensorboardX tqdm' \
+    && pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple \
+    && pip install $pythonPkg

--- a/images/tf113-cuda10/readme.md
+++ b/images/tf113-cuda10/readme.md
@@ -1,0 +1,35 @@
+Based on official image tensorflow/tensorflow:1.13.0rc1-gpu-py3 of Tensorflow
+need nvidia runtime support
+python 3.5
+with tmux screen vim
+pip list
+Package              Version               
+-------------------- ----------------------
+absl-py              0.7.0                 
+astor                0.7.1                 
+gast                 0.2.2                 
+grpcio               1.18.0                
+h5py                 2.9.0                 
+Keras-Applications   1.0.7                 
+Keras-Preprocessing  1.0.9                 
+lmdb                 0.94                  
+Markdown             3.0.1                 
+mock                 2.0.0                 
+numpy                1.16.1                
+opencv-python        4.1.0.25              
+pbr                  5.1.2                 
+pip                  19.0.1                
+protobuf             3.6.1                 
+pycurl               7.43.0                
+pygobject            3.20.0                
+python-apt           1.1.0b1+ubuntu0.16.4.2
+setuptools           40.8.0                
+six                  1.12.0                
+tensorboard          1.12.2                
+tensorboardX         1.7                   
+tensorflow-estimator 1.13.0rc0             
+tensorflow-gpu       1.13.0rc1             
+termcolor            1.1.0                 
+tqdm                 4.32.1                
+Werkzeug             0.14.1                
+wheel                0.29.0    


### PR DESCRIPTION
I have noticed that there is no one of the images support **cuda10**, and I can never use **tensorflow ~> 1.13** with available images. Therefore, I think this image may by useful.